### PR TITLE
Agent Plugins 1.0.0 conformance: canonical root plugin.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,13 +345,17 @@ jobs:
                   name.endswith(f"/skills/{skill}/agents/openai.yaml")
                   for name in source_names
               ), skill
+          relative_members = {
+              name.split("/", 1)[1] for name in source_names if "/" in name
+          }
           for plugin_file in {
+              "plugin.json",
               ".codex-plugin/plugin.json",
               ".agents/plugins/marketplace.json",
               ".claude-plugin/plugin.json",
               ".claude-plugin/marketplace.json",
           }:
-              assert any(name.endswith("/" + plugin_file) for name in source_names), plugin_file
+              assert plugin_file in relative_members, plugin_file
           assert not any("/__pycache__/" in name for name in source_names)
           assert not any(name.endswith((".pyc", ".pyo")) for name in source_names)
           assert not any("/fixtures/evidence/" in name for name in source_names)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,14 @@ versions as described in the [compatibility policy](docs/COMPATIBILITY.md).
 
 ### Added
 
+- The repository root is now a conformant [Agent Plugins](https://agent-plugins.org/)
+  1.0.0 package: a root `plugin.json` carries the standard `$schema` and the
+  same metadata as the client-specific manifests, and the existing `skills/`
+  tree is the standard's fixed skill discovery location. Clients implementing
+  the vendor-neutral standard can install OpenADA directly from the repository;
+  the `.claude-plugin/`, `.codex-plugin/`, and `.agents/` manifests are
+  unchanged and stay version-locked with the root manifest.
+
 - One canonical netlist, four PDKs. A published Simra deck now names a
   technology-independent *device role* (`nmos.core`, `pmos.core`, and
   `.lvt`/`.hvt`/`.io` variants) and SI geometry, and the binding profile

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include CHANGELOG.md
+include plugin.json
 include CONTRIBUTING.md
 include SECURITY.md
 recursive-include bin *

--- a/README.md
+++ b/README.md
@@ -464,6 +464,16 @@ for skill in skills/*; do
 done
 ```
 
+### Agent Plugins standard clients
+
+The repository root is a conformant [Agent Plugins](https://agent-plugins.org/)
+1.0.0 package: `plugin.json` is the manifest and `skills/` holds the Agent
+Skills. Any client that implements the standard can install OpenADA directly
+from this repository with its own plugin mechanism — no OpenADA-specific
+adapter is involved. The `.claude-plugin/`, `.codex-plugin/`, and `.agents/`
+directories remain for clients with their own pre-standard discovery and carry
+the same skill tree and metadata.
+
 ### Other harnesses
 
 Make `bin/openada` available to the agent's terminal and register the desired

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "openada",
+  "version": "0.4.0",
+  "description": "Open agent-EDA contracts, deterministic drivers, and tool-independent engineering skills.",
+  "author": {
+    "name": "Simra Tech",
+    "url": "https://github.com/simra-tech"
+  },
+  "homepage": "https://www.simratech.com/openada/",
+  "repository": "https://github.com/simra-tech/OpenADA",
+  "license": "MIT",
+  "keywords": [
+    "eda",
+    "semiconductors",
+    "agents",
+    "xschem",
+    "ngspice",
+    "xyce",
+    "verilator",
+    "yosys",
+    "opensta",
+    "openroad",
+    "librelane",
+    "asic",
+    "pdk",
+    "engineering-workflows",
+    "klayout"
+  ]
+}

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -10,6 +10,20 @@ from openada import __version__
 ROOT = Path(__file__).parents[1]
 SKILLS_ROOT = ROOT / "skills"
 SKILL_NAME = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*\Z")
+AGENT_PLUGINS_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+AGENT_PLUGINS_MANIFEST_FIELDS = {
+    "$schema",
+    "name",
+    "version",
+    "description",
+    "author",
+    "homepage",
+    "repository",
+    "license",
+    "keywords",
+    "extensions",
+}
+AGENT_PLUGINS_NAME = re.compile(r"[a-z0-9]+(?:[-.][a-z0-9]+)*\Z")
 ANALOG_SKILLS = {
     "characterize-analog-block",
     "analyze-feedback-stability",
@@ -114,6 +128,34 @@ def test_circuit_execution_reference_is_bounded_and_contract_complete():
     assert "direct simulator command" in text
 
 
+def test_root_manifest_conforms_to_agent_plugins_1_0_0():
+    manifest = json.loads((ROOT / "plugin.json").read_text(encoding="utf-8"))
+
+    assert manifest["$schema"] == AGENT_PLUGINS_SCHEMA
+    assert set(manifest) <= AGENT_PLUGINS_MANIFEST_FIELDS
+    assert manifest["name"] == "openada"
+    assert AGENT_PLUGINS_NAME.fullmatch(manifest["name"])
+    assert 1 <= len(manifest["name"]) <= 64
+    assert set(manifest["author"]) <= {"name", "email", "url"}
+    assert all(
+        isinstance(manifest[key], str)
+        for key in ("version", "description", "homepage", "repository", "license")
+    )
+    assert all(isinstance(keyword, str) for keyword in manifest["keywords"])
+
+
+def test_root_manifest_matches_the_claude_manifest_metadata():
+    root_manifest = json.loads((ROOT / "plugin.json").read_text(encoding="utf-8"))
+    claude_manifest = json.loads(
+        (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+
+    for key in ("name", "version", "description", "author", "homepage",
+                "repository", "license"):
+        assert root_manifest[key] == claude_manifest[key], key
+    assert set(root_manifest["keywords"]) >= set(claude_manifest["keywords"])
+
+
 def test_codex_manifest_discovers_the_shared_skills_directory():
     manifest = json.loads(
         (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
@@ -162,12 +204,14 @@ def test_package_runtime_and_plugin_release_versions_match():
     claude_manifest = json.loads(
         (ROOT / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
     )
+    root_manifest = json.loads((ROOT / "plugin.json").read_text(encoding="utf-8"))
 
     versions = {
         package_match.group(1),
         __version__,
         codex_manifest["version"],
         claude_manifest["version"],
+        root_manifest["version"],
     }
     assert versions == {__version__}
     assert __version__ == "0.4.0"
@@ -175,6 +219,7 @@ def test_package_runtime_and_plugin_release_versions_match():
 
 def test_both_plugin_manifests_advertise_the_digital_connectors():
     for path in (
+        ROOT / "plugin.json",
         ROOT / ".codex-plugin" / "plugin.json",
         ROOT / ".claude-plugin" / "plugin.json",
     ):


### PR DESCRIPTION
## What

Makes the repository root a conformant [Agent Plugins 1.0.0](https://agent-plugins.org/) package — the vendor-neutral plugin standard published 2026-08-06 by OpenAI, Amazon, Microsoft, Cursor, and Vercel (Google as Core Maintainer), with launch support in ChatGPT, Codex, Cursor, GitHub Copilot, Kiro, and VS Code.

OpenADA was already almost conformant: the standard mandates the Agent Skills `SKILL.md` format our `skills/` tree already follows, and `skills/` is the standard's fixed discovery location. The only missing piece was a root manifest.

## Changes

- **`plugin.json` (new, root)** — standard `$schema` + the closed field set of spec §5.2; same metadata as `.claude-plugin/plugin.json`, keywords are the Codex-manifest superset. Validated against the canonical published JSON Schema.
- **`tests/test_plugin_skills.py`** — new conformance test (schema id, field closure, §5.5 name grammar, author shape), metadata-parity test against the Claude manifest; version lock and connector checks now cover five manifests.
- **`.github/workflows/ci.yml`** — sdist manifest assertion now checks exact relative paths; the previous `endswith` check would have false-passed the root `plugin.json` via `.claude-plugin/plugin.json`.
- **`MANIFEST.in`** — root manifest ships in the sdist (verified locally against the new CI assertion).
- **README / CHANGELOG** — standard-client install note; 0.4.0 entry.

Client-specific manifests (`.claude-plugin/`, `.codex-plugin/`, `.agents/`) are unchanged; the Codex `skills`/`interface` extras can migrate to the standard's `extensions` namespaces once Codex consumes the standard directly.

Not included (deliberate): `mcp.json` is optional in the spec and stays absent per `docs/PROVIDERS_AND_MCP.md` — wrapping the provider runtime as an MCP server is a separate direction decision.

## Verification

- `tests/test_plugin_skills.py`: 21/21 pass
- `plugin.json` validates against `schemas/1.0.0/plugin.schema.json` from the spec repo
- sdist built locally; all five manifests present under the new exact-path assertion